### PR TITLE
fix install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This tool will check type of all identifiers, `the code coverage` = `the count o
 
 ## install
 
-`yarn add global type-coverage`
+`yarn global add type-coverage`
 
 ## usage
 


### PR DESCRIPTION
#### Fixes(if relevant):

The install script.

Previously it installed `global` and `type-coverage` into the project. Now it installs `type-coverage` globally.

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
