### PR TITLE
Add explanation of what happens to .js files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A CLI tool to check type coverage for typescript code
 
-This tool will check type of all identifiers, `the code coverage` = `the count of identifiers whose type is not any` / `the total count of identifiers`, the higher, the better.
+This tool will check type of all identifiers, `the code coverage` = `the count of identifiers whose type is not any` / `the total count of identifiers`, the higher, the better. This count will include JavaScript files inside the same project structure (all the identifiers in these files are untyped). 
 
 [![Dependency Status](https://david-dm.org/plantain-00/type-coverage.svg)](https://david-dm.org/plantain-00/type-coverage)
 [![devDependency Status](https://david-dm.org/plantain-00/type-coverage/dev-status.svg)](https://david-dm.org/plantain-00/type-coverage#info=devDependencies)


### PR DESCRIPTION
See issue #9 for more details, but basically this adds a description to the README of what happens to JavaScript files that are part of a TypeScript project.