### PR TITLE
add --ignore-catch functionality

### DIFF
--- a/.type-coverage/result.json
+++ b/.type-coverage/result.json
@@ -13,15 +13,15 @@
       ]
     },
     "src/interfaces.ts": {
-      "hash": "8148a2398fd296027e0685617bbe40552a53975d",
-      "correctCount": 44,
-      "totalCount": 44,
+      "hash": "7715bcc147c954dce510985eb9c9b224215b0510",
+      "correctCount": 47,
+      "totalCount": 47,
       "anys": []
     },
     "src/checker.ts": {
-      "hash": "fc598a81318c5a6a321b8f481d603b27454b442c",
-      "correctCount": 2634,
-      "totalCount": 2636,
+      "hash": "fab3ea8e1cca14f219b6958a9c8f146345172824",
+      "correctCount": 2674,
+      "totalCount": 2676,
       "anys": [
         {
           "line": 21,
@@ -49,18 +49,18 @@
     },
     "src/cache.ts": {
       "hash": "8ff65e5859ffb69974319bb63a599a1dbd4f9506",
-      "correctCount": 101,
-      "totalCount": 101,
+      "correctCount": 99,
+      "totalCount": 99,
       "anys": []
     },
     "src/core.ts": {
-      "hash": "eee1df4d1d8684b5595f7c7532f0baaa7d29603d",
-      "correctCount": 221,
-      "totalCount": 221,
+      "hash": "8c86df1cc8bf52c3950c13cb4710d5c100987ce2",
+      "correctCount": 224,
+      "totalCount": 224,
       "anys": []
     },
     "src/index.ts": {
-      "hash": "a261a5eaa4bde81f7afce7265526efad8454b32f",
+      "hash": "61aab3522714d3a55baff2c3a21a2c9bb40226ff",
       "correctCount": 134,
       "totalCount": 145,
       "anys": [
@@ -105,17 +105,17 @@
           "text": "cache"
         },
         {
-          "line": 40,
+          "line": 41,
           "character": 11,
           "text": "detail"
         },
         {
-          "line": 73,
+          "line": 74,
           "character": 6,
           "text": "error"
         },
         {
-          "line": 76,
+          "line": 77,
           "character": 16,
           "text": "error"
         }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ name | type | description
 `--at-least` | number? | fail if coverage rate < this value
 `--debug` | boolean? | show debug info
 `--strict` | boolean? | [strict mode](#strict-mode)
+`--ignoreCatch` | boolean? | [ignore catch](#ignore-catch)
 `--cache` | boolean? | [enable cache](#enable-cache)
 
 ### strict mode
@@ -40,6 +41,26 @@ Also, future minor release may introduce stricter type check in this mode, which
 ### enable cache
 
 save and reuse type check result of files that is unchanged and independent of changed files in `.type-coverage` directory, to improve speed
+
+### ignore catch
+
+If you want to get 100% type coverage then `try {} catch {}` is
+the largest blocked towards that.
+
+This can be fixed in typescript with [Allow type annotation on catch clause variable](https://github.com/Microsoft/TypeScript/issues/20024)
+but until then you can turn on `--ignoreCatch --at-least 100`.
+
+Your catch blocks should look like
+
+```ts
+try {
+  await ...
+} catch (anyErr) {
+  const err = <Error> anyErr
+}
+```
+
+To have the highest type coverage.
 
 ## config in package.json
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ name | type | description
 `--at-least` | number? | fail if coverage rate < this value
 `--debug` | boolean? | show debug info
 `--strict` | boolean? | [strict mode](#strict-mode)
-`--ignoreCatch` | boolean? | [ignore catch](#ignore-catch)
+`--ignore-catch` | boolean? | [ignore catch](#ignore-catch)
 `--cache` | boolean? | [enable cache](#enable-cache)
 
 ### strict mode
@@ -48,7 +48,7 @@ If you want to get 100% type coverage then `try {} catch {}` is
 the largest blocked towards that.
 
 This can be fixed in typescript with [Allow type annotation on catch clause variable](https://github.com/Microsoft/TypeScript/issues/20024)
-but until then you can turn on `--ignoreCatch --at-least 100`.
+but until then you can turn on `--ignore-catch --at-least 100`.
 
 Your catch blocks should look like
 
@@ -103,7 +103,8 @@ export function lint(
   files?: string[],
   oldProgram?: ts.Program,
   strict = false,
-  enableCache = false
+  enableCache = false,
+  ignoreCatch = false
 ): Promise<{
   correctCount: number
   totalCount: number

--- a/src/core.ts
+++ b/src/core.ts
@@ -16,7 +16,8 @@ export async function lint(
   files?: string[],
   oldProgram?: ts.Program,
   strict = false,
-  enableCache = false
+  enableCache = false,
+  ignoreCatch = false
 ) {
   const { configFilePath, dirname } = getTsConfigFilePath(project)
   const config = getTsConfig(configFilePath, dirname)
@@ -80,6 +81,8 @@ export async function lint(
         totalCount: 0,
         anys: []
       },
+      ignoreCatch,
+      catchVariables: {},
       debug,
       detail,
       strict,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ async function executeCommandLine() {
     undefined,
     undefined,
     argv.strict,
-    argv.cache
+    argv.cache,
+    argv.ignoreCatch
   )
   const percent = Math.round(10000 * correctCount / totalCount) / 100
   const atLeast = await getAtLeast(argv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ async function executeCommandLine() {
     undefined,
     argv.strict,
     argv.cache,
-    argv.ignoreCatch
+    argv['ignore-catch']
   )
   const percent = Math.round(10000 * correctCount / totalCount) / 100
   const atLeast = await getAtLeast(argv)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,8 @@ export interface FileContext {
   detail: boolean
   strict: boolean
   checker: ts.TypeChecker
+  ignoreCatch: boolean
+  catchVariables: { [variable: string]: boolean }
   ingoreMap: { [file: string]: Set<number> }
 }
 


### PR DESCRIPTION
#### Fixes(if relevant): 

Introduces a new flag `--ignore-catch`;

### ignore catch

 If you want to get 100% type coverage then `try {} catch {}` is
the largest blocked towards that.

 This can be fixed in typescript with [Allow type annotation on catch clause variable](https://github.com/Microsoft/TypeScript/issues/20024)
but until then you can turn on `--ignoreCatch --at-least 100`.

 Your catch blocks should look like

 ```
try {
  await ...
} catch (anyErr) {
  const err = <Error> anyErr
}
```

 To have the highest type coverage.

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [x] Add Test(if relevant, `npm run test` to check)
