### PR TITLE
Fix link to codechecks.io in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Use your own project url:
 
 ## integrating with PRs
 
-Using [codechecks](codechecks.io) you can integrate `type-coverage` with GitHub's Pull Requests. See [type-coverage-watcher](https://github.com/codechecks/type-coverage-watcher).
+Using [codechecks](https://codechecks.io) you can integrate `type-coverage` with GitHub's Pull Requests. See [type-coverage-watcher](https://github.com/codechecks/type-coverage-watcher).
 
 [![type-coverage-watcher](https://github.com/codechecks/type-coverage-watcher/raw/master/meta/check.png "type-coverage-watcher")](https://github.com/codechecks/type-coverage-watcher)
 


### PR DESCRIPTION
#### Fixes(if relevant): 
+ codechecks.io link in README now works as expected (was missing `https://`)

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [x] Add Test(if relevant, `npm run test` to check)
+ [x] Add Demo(if relevant)
