### PR TITLE
fix: wrong extends for tsconfig.json in node_modules

### DIFF
--- a/packages/utils/src/tsconfig.ts
+++ b/packages/utils/src/tsconfig.ts
@@ -59,7 +59,22 @@ function getTsConfig(configFilePath: string, dirname: string): JsonConfig {
     }
   } : configResult.config as JsonConfig
   if (config.extends) {
-    const project = path.resolve(dirname, config.extends)
+    let project: string
+    if (path.isAbsolute(config.extends)) {
+      project = config.extends
+    } else if (config.extends === '.'
+      || config.extends === '..'
+      || config.extends.startsWith(`.${path.sep}`)
+      || config.extends.startsWith(`..${path.sep}`)
+      || config.extends.startsWith('./')
+      || config.extends.startsWith('../')
+    ) {
+      project = path.resolve(dirname, config.extends)
+    } else if (config.extends.endsWith('.json')) {
+      project = path.resolve(dirname, 'node_modules', config.extends)
+    } else {
+      project = path.resolve(dirname, 'node_modules', config.extends + '.json')
+    }
     const { configFilePath, dirname: extendsBasename } = getTsConfigFilePath(project)
     const extendsConfig = getTsConfig(configFilePath, extendsBasename)
     config.compilerOptions = { ...extendsConfig.compilerOptions, ...config.compilerOptions }


### PR DESCRIPTION
#### Fixes(if relevant): #33 

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [ ] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
