### PR TITLE
Added fileCounts to core lint api with flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,18 @@ export interface LintOptions {
   strict: boolean,
   enableCache: boolean,
   ignoreCatch: boolean,
-  ignoreFiles?: string | string[]
+  ignoreFiles?: string | string[],
+  fileCounts: boolean,
 }
 
 export interface FileTypeCheckResult {
   correctCount: number
   totalCount: number
   anys: FileAnyInfo[]
+  fileCounts: {
+    correctCount: number,
+    totalCount: number,
+  }[]
 }
 ```
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -27,6 +27,7 @@ export interface LintOptions {
   enableCache: boolean,
   ignoreCatch: boolean,
   ignoreFiles?: string | string[]
+  fileCounts: boolean,
 }
 
 export interface FileContext {


### PR DESCRIPTION
#### Fixes(if relevant): 
#36 

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)

For now I've just included this in core with API access as that's all I really needed it for, but am open to adding in CLI support if you feel it needs it.

It would have been nice to include the `anys` for each file as well however I found I was running up against memory and performance issues for large projects pretty quickly by retaining all of these per file, so it's just including the correct and total counts per file, which I think are the main things to be looking for anyway.