### PR TITLE
chore: add processAny api

### DIFF
--- a/.type-coverage/result.json
+++ b/.type-coverage/result.json
@@ -19,15 +19,15 @@
       "anys": []
     },
     "packages/core/src/interfaces.ts": {
-      "hash": "24705c8d08a7d16b8eee13ad0670c5137fb7dbd2",
-      "correctCount": 58,
-      "totalCount": 58,
+      "hash": "16753950d12128f4647034b941a5af4ed4bae3e5",
+      "correctCount": 68,
+      "totalCount": 68,
       "anys": []
     },
     "packages/core/src/checker.ts": {
-      "hash": "1a913aafde8f499085791b2349f084aa7219de5c",
-      "correctCount": 2679,
-      "totalCount": 2679,
+      "hash": "28e7e09f3709203a1a3388982a83dd5d76d0b42c",
+      "correctCount": 2687,
+      "totalCount": 2687,
       "anys": []
     },
     "packages/core/src/dependencies.ts": {
@@ -49,9 +49,9 @@
       "anys": []
     },
     "packages/core/src/core.ts": {
-      "hash": "1c65788fbc071b8446a6480dea19e9773696b854",
-      "correctCount": 278,
-      "totalCount": 278,
+      "hash": "dbd1337fdc2f2d9807647dde181a9ac73d9bdd94",
+      "correctCount": 281,
+      "totalCount": 281,
       "anys": []
     },
     "packages/core/src/index.ts": {
@@ -61,9 +61,9 @@
       "anys": []
     },
     "packages/core/dist/interfaces.d.ts": {
-      "hash": "5a72d4ffd7e333e4967fa886972c4fea366b557e",
-      "correctCount": 58,
-      "totalCount": 58,
+      "hash": "340bc4d89d07361d4904d936c2f9a71b01d4ca08",
+      "correctCount": 68,
+      "totalCount": 68,
       "anys": []
     },
     "packages/core/dist/core.d.ts": {

--- a/packages/core/src/checker.ts
+++ b/packages/core/src/checker.ts
@@ -2,7 +2,11 @@ import ts from 'typescript'
 
 import { FileContext } from './interfaces'
 
-function collectAny(node: ts.Node, { file, sourceFile, typeCheckResult, ingoreMap, debug }: FileContext) {
+function collectAny(node: ts.Node, context: FileContext) {
+  const { file, sourceFile, typeCheckResult, ingoreMap, debug, processAny } = context
+  if (processAny !== undefined) {
+    return processAny(node, context)
+  }
   const { line, character } = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile))
   if (ingoreMap[file] && ingoreMap[file].has(line)) {
     return false

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -100,8 +100,9 @@ export async function lint(project: string, options?: Partial<LintOptions>) {
       catchVariables: {},
       debug: lintOptions.debug,
       strict: lintOptions.strict,
+      processAny: lintOptions.processAny,
       checker,
-      ingoreMap
+      ingoreMap,
     }
 
     sourceFile.forEachChild(node => {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -19,6 +19,11 @@ interface FileAnyInfo {
   text: string
 }
 
+/**
+ * @public
+ */
+export type ProccessAny = (node: ts.Node, context: FileContext) => boolean
+
 export interface LintOptions {
   debug: boolean,
   files?: string[],
@@ -29,6 +34,7 @@ export interface LintOptions {
   ignoreFiles?: string | string[]
   fileCounts: boolean,
   absolutePath?: boolean,
+  processAny?: ProccessAny,
 }
 
 export interface FileContext {
@@ -41,6 +47,7 @@ export interface FileContext {
   ignoreCatch: boolean
   catchVariables: { [variable: string]: boolean }
   ingoreMap: { [file: string]: Set<number> }
+  processAny?: ProccessAny
 }
 
 interface TypeCheckCache extends FileTypeCheckResult {


### PR DESCRIPTION
#### Changes
I want to override default behavior, by using checker.getSymbolAtLocation to get identifier declaration, than filter same any. 

Idea is to get any origins to avoid duplicates. But could be problems with types, declared in other files.



#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
