### PR TITLE
Add an option to ignore unread ("evolving") anys

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -98,6 +98,7 @@ export async function lint(project: string, options?: Partial<LintOptions>) {
         anys: []
       },
       ignoreCatch: lintOptions.ignoreCatch,
+      ignoreUnreadAnys: lintOptions.ignoreUnreadAnys,
       catchVariables: {},
       debug: lintOptions.debug,
       strict: lintOptions.strict,
@@ -152,6 +153,7 @@ const defaultLintOptions: LintOptions = {
   enableCache: false,
   ignoreCatch: false,
   ignoreFiles: undefined,
+  ignoreUnreadAnys: false,
   fileCounts: false,
 }
 
@@ -207,6 +209,7 @@ export function lintSync(compilerOptions: ts.CompilerOptions, rootNames: string[
         anys: []
       },
       ignoreCatch: lintOptions.ignoreCatch,
+      ignoreUnreadAnys: lintOptions.ignoreUnreadAnys,
       catchVariables: {},
       debug: lintOptions.debug,
       strict: lintOptions.strict,

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -43,7 +43,8 @@ export interface LintOptions {
   strict: boolean,
   enableCache: boolean,
   ignoreCatch: boolean,
-  ignoreFiles?: string | string[]
+  ignoreFiles?: string | string[],
+  ignoreUnreadAnys: boolean,
   fileCounts: boolean,
   absolutePath?: boolean,
   processAny?: ProccessAny,
@@ -57,6 +58,7 @@ export interface FileContext {
   strict: boolean
   checker: ts.TypeChecker
   ignoreCatch: boolean
+  ignoreUnreadAnys: boolean
   catchVariables: { [variable: string]: boolean }
   ingoreMap: { [file: string]: Set<number> }
   processAny?: ProccessAny


### PR DESCRIPTION
#### Fixes(if relevant): #28 

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [ ] Lint Success(`npm run lint` to check, `npm run fix` to fix): there were lint failures but not related to my code
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check): I can't find any tests in this repo, please advise!
+ [ ] Add Demo(if relevant): I'd love to add one, please let me know how

Test/demo file:

```ts
$ cat test.ts
let val;  // any
if (Math.random() < 0.5) {
  val = /hello/;  // any
  val  // RegExp
} else {
  val = 12;  // any
  val  // number
}
val  // number | RegExp
```

Without the new flag: lines 1, 3 and 6 are flagged as `any`s
With the new flag: no errors are flagged

Anecdotally, here's the diff for my project:

    54890 / 55533 98.84% Before
    55110 / 55533 99.23% After

So this removed 220/643 of the issues flagged by `type-coverage`. I skimmed through many of these and they seemed fine.

This is a long-standing pattern that has been allowed in TS since [version 2.1](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#improved-any-inference).