### PR TITLE
Fix issue with extends behavior with types & baseUrl

### DIFF
--- a/packages/utils/src/tsconfig.ts
+++ b/packages/utils/src/tsconfig.ts
@@ -54,7 +54,7 @@ function getTsConfigFilePath(project: string, fallbackProject?: string[]) {
 
 interface JsonConfig {
   extends?: string
-  compilerOptions?: { [name: string]: unknown }
+  compilerOptions?: { baseUrl?: string; [name: string]: unknown }
   include?: string[]
   exclude?: string[]
   files?: string[]
@@ -97,7 +97,7 @@ async function getTsConfig(configFilePath: string, dirname: string): Promise<Jso
     const { configFilePath, dirname: extendsBasename } = getTsConfigFilePath(project, fallbackProjects)
     const extendsConfig = await getTsConfig(configFilePath, extendsBasename)
     config.compilerOptions = { ...extendsConfig.compilerOptions, ...config.compilerOptions }
-    config.basePath = extendsBasename
+    config.basePath = config.compilerOptions.baseUrl || extendsBasename;
   }
   return config
 }


### PR DESCRIPTION
#### Fixes(if relevant): 

My project worked fine when using a single configuration aka `jsconfig.json` or `tsconfig.json`.

Once i used the `extends` feature and split it out into two files it didn't work.

This was caused by ignoring the `baseUrl` I set and overwriting it incorrectly with a `basePath`.

#### Checks

+ [X] Contains Only One Commit(`git reset` then `git commit`)
+ [X] Build Success(`npm run build`)
+ [X] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [X] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
