### PR TITLE
Only respect top level base url

### DIFF
--- a/packages/utils/src/tsconfig.ts
+++ b/packages/utils/src/tsconfig.ts
@@ -96,8 +96,9 @@ async function getTsConfig(configFilePath: string, dirname: string): Promise<Jso
     }
     const { configFilePath, dirname: extendsBasename } = getTsConfigFilePath(project, fallbackProjects)
     const extendsConfig = await getTsConfig(configFilePath, extendsBasename)
+    const topLevelBaseUrl = config.compilerOptions ? config.compilerOptions.baseUrl : undefined
     config.compilerOptions = { ...extendsConfig.compilerOptions, ...config.compilerOptions }
-    config.basePath = config.compilerOptions.baseUrl || extendsBasename;
+    config.basePath = topLevelBaseUrl ? dirname : extendsBasename;
   }
   return config
 }


### PR DESCRIPTION
#### Fixes(if relevant): 

I did some further debugging. The behavior actually has to be different depending on whether the top level configuration sets `baseUrl` or whether the config we are extending sets `baseUrl`.

The change merged onto master breaks code bases where a `baseUrl` is set in the extends target.

Also the previous change only worked because my `baseUrl` happened to be `./`; the value we want is `dirname`, not `baseUrl`, it just happens to be that they are the same when `baseUrl` is `./`.

I tried few more permutations of settings `baseUrl` in my `jsconfig.json` and my `base-tsconfig.json` files to make sure this change is actually correct.

Note that previously master was still broken when using `baseUrl` & `extends` together.

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
