### PR TITLE
Add an option to save coverage history on a target file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ name | type | description
 `--ignore-type-assertion` | boolean? | ignore type assertion, eg: `<string>foo`(Added in `v2.16`)
 `--ignore-non-null-assertion` | boolean? | ignore non-null assertion, eg: `foo!`(Added in `v2.16`)
 `--show-relative-path` | boolean? | show relative path in detail message(Added in `v2.17`)
+`--history-file` | string? | file name where history is saved
 
 ### strict mode
 
@@ -104,7 +105,8 @@ This tool will ignore the files, eg: `--ignore-files "demo1/*.ts" --ignore-files
     "ignoreAsAssertion": true, // same as --ignore-as-assertion (Added in `v2.16`)
     "ignoreTypeAssertion": true, // same as --ignore-type-assertion (Added in `v2.16`)
     "ignoreNonNullAssertion": true, // same as --ignore-non-null-assertion (Added in `v2.16`)
-    "showRelativePath": true // same as --show-relative-path (Added in `v2.17`)
+    "showRelativePath": true, // same as --show-relative-path (Added in `v2.17`)
+    "historyFile": "typecoverage.json" // same as --history-file
   },
 ```
 


### PR DESCRIPTION
#### Fixes(if relevant): 


#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [x] File Integrity(`git add -A` or add rules at `.gitignore` file)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
