### PR TITLE
ci: include lts node version matrix

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -2,6 +2,10 @@ name: Github CI
 
 on: [push]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
 
@@ -9,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18, 20, 22]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: git fetch --unshallow || true


### PR DESCRIPTION
#### Changes :
Bump `actions/checkout` from `v2` to `v4`
Bump `actions/setup-node` from `v1` to `v4`
More secure workflow permissions
Added current lts and latest Node version to the strategy matrix.

#### Fixes(if relevant): 

#### Checks

+ [X] Contains Only One Commit(`git reset` then `git commit`)
+ [X] Build Success(`npm run build`)
+ [X] Lint Success(`npm run lint` to check, `npm run fix` to fix)

Appveyor should also run tests on more Node.js versions, but I'm not familiar with this tool, so I'd prefer to let someone else who is more familiar with it make those edits.


*Thanks for this tool!*
